### PR TITLE
Stage 1 async command data fetching and caches

### DIFF
--- a/src/main/kotlin/pl/syntaxdevteam/punisher/PunisherX.kt
+++ b/src/main/kotlin/pl/syntaxdevteam/punisher/PunisherX.kt
@@ -94,6 +94,9 @@ class PunisherX : JavaPlugin(), Listener {
      * Closes the database connection and unregisters events.
      */
     override fun onDisable() {
+        if (this::punishmentService.isInitialized) {
+            punishmentService.shutdown()
+        }
         databaseHandler.closeConnection()
         AsyncChatEvent.getHandlerList().unregister(this as Plugin)
         pluginInitializer.onDisable()
@@ -123,6 +126,9 @@ class PunisherX : JavaPlugin(), Listener {
      * Reloads the plugin configuration and reinitializes the database connection.
      */
     private fun reloadMyConfig() {
+        if (this::punishmentService.isInitialized) {
+            punishmentService.shutdown()
+        }
         databaseHandler.closeConnection()
         try {
             messageHandler.reloadMessages()

--- a/src/main/kotlin/pl/syntaxdevteam/punisher/commands/CommandFutures.kt
+++ b/src/main/kotlin/pl/syntaxdevteam/punisher/commands/CommandFutures.kt
@@ -1,0 +1,24 @@
+package pl.syntaxdevteam.punisher.commands
+
+import io.papermc.paper.command.brigadier.CommandSourceStack
+import pl.syntaxdevteam.punisher.PunisherX
+import pl.syntaxdevteam.punisher.common.thenOnMainThread
+import java.util.concurrent.CompletableFuture
+
+fun <T> CompletableFuture<T>.deliverToCommand(
+    plugin: PunisherX,
+    stack: CommandSourceStack,
+    actionDescription: String,
+    onSuccess: (T) -> Unit
+) {
+    this.whenComplete { _, throwable ->
+        if (throwable != null) {
+            plugin.logger.err("Failed to $actionDescription: ${throwable.message}")
+            plugin.taskDispatcher.runSync {
+                stack.sender.sendMessage(plugin.messageHandler.getMessage("error", "db_error"))
+            }
+        }
+    }.thenOnMainThread(plugin.taskDispatcher) { result ->
+        onSuccess(result)
+    }
+}

--- a/src/main/kotlin/pl/syntaxdevteam/punisher/commands/HistoryCommand.kt
+++ b/src/main/kotlin/pl/syntaxdevteam/punisher/commands/HistoryCommand.kt
@@ -5,6 +5,7 @@ import io.papermc.paper.command.brigadier.CommandSourceStack
 import org.bukkit.Bukkit
 import org.jetbrains.annotations.NotNull
 import pl.syntaxdevteam.punisher.PunisherX
+import pl.syntaxdevteam.punisher.databases.PunishmentData
 import pl.syntaxdevteam.punisher.permissions.PermissionChecker
 import pl.syntaxdevteam.punisher.players.PlayerIPManager
 import java.text.SimpleDateFormat
@@ -33,67 +34,34 @@ class HistoryCommand(private val plugin: PunisherX, private val playerIPManager:
                 null -> Bukkit.getOfflinePlayer(uuid).name
                 else -> Bukkit.getPlayer(player)?.name
             }
-            val punishments = plugin.databaseHandler.getPunishmentHistory(uuid.toString(), limit, offset)
-
-            if (punishments.isEmpty()) {
-                stack.sender.sendMessage(
-                    plugin.messageHandler.getMessage(
-                        "history",
-                        "no_punishments",
-                        mapOf("player" to player)
+            plugin.punishmentService.getPunishmentHistory(uuid, limit, offset)
+                .thenApply { punishments ->
+                    val playerIP = playerIPManager.getPlayerIPByName(player)
+                    plugin.logger.debug("Player IP: $playerIP")
+                    val geoLocation = playerIP?.let { resolveGeoLocation(it) } ?: UNKNOWN_LOCATION
+                    plugin.logger.debug("GeoLocation: $geoLocation")
+                    HistoryResult(
+                        uuid = uuid,
+                        targetPlayer = targetPlayer,
+                        punishments = punishments,
+                        playerIP = playerIP,
+                        geoLocation = geoLocation,
+                        page = page
                     )
-                )
-            } else {
-                val id = plugin.messageHandler.getCleanMessage("history", "id")
-                val types = plugin.messageHandler.getCleanMessage("history", "type")
-                val reasons = plugin.messageHandler.getCleanMessage("history", "reason")
-                val times = plugin.messageHandler.getCleanMessage("history", "time")
-                val title = plugin.messageHandler.getCleanMessage("history", "title")
-                val playerIP = playerIPManager.getPlayerIPByName(player)
-                plugin.logger.debug("Player IP: $playerIP")
-                val geoLocation = playerIP?.let { ip ->
-                    val country = playerIPManager.geoIPHandler.getCountry(ip)
-                    val city = playerIPManager.geoIPHandler.getCity(ip)
-                    plugin.logger.debug("Country: $country, City: $city")
-                    "$city, $country"
-                } ?: "Unknown location"
-                plugin.logger.debug("GeoLocation: $geoLocation")
-                val fullGeoLocation = when (stack.sender.hasPermission("punisherx.view_ip")) {
-                    true -> "$playerIP ($geoLocation)"
-                    else -> geoLocation
                 }
-                val gamer = if (stack.sender.name == "CONSOLE") {
-                    "<gold>$targetPlayer <gray>[$uuid, $fullGeoLocation]</gray>:</gold>"
-                } else {
-                    "<gold><hover:show_text:'[<white>$uuid, $fullGeoLocation</white>]'>$targetPlayer:</gold>"
+                .deliverToCommand(plugin, stack, "fetch punishment history for $player") { result ->
+                    if (result.punishments.isEmpty()) {
+                        stack.sender.sendMessage(
+                            plugin.messageHandler.getMessage(
+                                "history",
+                                "no_punishments",
+                                mapOf("player" to player)
+                            )
+                        )
+                    } else {
+                        renderHistory(stack, player, result)
+                    }
                 }
-                val mh = plugin.messageHandler
-                val topHeader =
-                    mh.miniMessageFormat("<blue>--------------------------------------------------</blue>")
-                val header = mh.miniMessageFormat("<blue>|    $title $gamer</blue>")
-                val tableHeader = mh.miniMessageFormat("<blue>|   $id  |  $types  |  $reasons  |  $times</blue>")
-                val br = mh.miniMessageFormat("<blue> </blue>")
-                val hr = mh.miniMessageFormat("<blue>|</blue>")
-                stack.sender.sendMessage(br)
-                stack.sender.sendMessage(header)
-                stack.sender.sendMessage(topHeader)
-                stack.sender.sendMessage(tableHeader)
-                stack.sender.sendMessage(hr)
-
-                punishments.forEach { punishment ->
-                    val formattedDate = dateFormat.format(Date(punishment.start))
-                    val punishmentMessage =
-                        mh.miniMessageFormat("<blue>|   <white>#${punishment.id}</white> <blue>|</blue> <white>${punishment.type}</white> <blue>|</blue> <white>${punishment.reason}</white> <blue>|</blue> <white>$formattedDate</blue>")
-                    stack.sender.sendMessage(punishmentMessage)
-                }
-                stack.sender.sendMessage(hr)
-
-                val nextPage = page + 1
-                val prevPage = if (page > 1) page - 1 else 1
-                val navigation =
-                    mh.miniMessageFormat("<blue>| <click:run_command:'/history $player $prevPage'>[Previous]</click>   <click:run_command:'/history $player $nextPage'>[Next]</click> </blue>")
-                stack.sender.sendMessage(navigation)
-            }
         } else {
             stack.sender.sendMessage(plugin.messageHandler.getMessage("history", "no_permission"))
         }
@@ -107,5 +75,69 @@ class HistoryCommand(private val plugin: PunisherX, private val playerIPManager:
             1 -> plugin.server.onlinePlayers.map { it.name }
             else -> emptyList()
         }
+    }
+
+    private fun resolveGeoLocation(ip: String): String {
+        val country = playerIPManager.geoIPHandler.getCountry(ip)
+        val city = playerIPManager.geoIPHandler.getCity(ip)
+        plugin.logger.debug("Country: $country, City: $city")
+        return "$city, $country"
+    }
+
+    private fun renderHistory(stack: CommandSourceStack, player: String, result: HistoryResult) {
+        val uuid = result.uuid
+        val mh = plugin.messageHandler
+        val id = mh.getCleanMessage("history", "id")
+        val types = mh.getCleanMessage("history", "type")
+        val reasons = mh.getCleanMessage("history", "reason")
+        val times = mh.getCleanMessage("history", "time")
+        val title = mh.getCleanMessage("history", "title")
+        val fullGeoLocation = if (stack.sender.hasPermission("punisherx.view_ip")) {
+            "${result.playerIP ?: UNKNOWN_LOCATION} (${result.geoLocation})"
+        } else {
+            result.geoLocation
+        }
+        val gamer = if (stack.sender.name == "CONSOLE") {
+            "<gold>${result.targetPlayer ?: player} <gray>[$uuid, $fullGeoLocation]</gray>:</gold>"
+        } else {
+            "<gold><hover:show_text:'[<white>$uuid, $fullGeoLocation</white>]'>${result.targetPlayer ?: player}:</gold>"
+        }
+        val topHeader = mh.miniMessageFormat("<blue>--------------------------------------------------</blue>")
+        val header = mh.miniMessageFormat("<blue>|    $title $gamer</blue>")
+        val tableHeader = mh.miniMessageFormat("<blue>|   $id  |  $types  |  $reasons  |  $times</blue>")
+        val br = mh.miniMessageFormat("<blue> </blue>")
+        val hr = mh.miniMessageFormat("<blue>|</blue>")
+        stack.sender.sendMessage(br)
+        stack.sender.sendMessage(header)
+        stack.sender.sendMessage(topHeader)
+        stack.sender.sendMessage(tableHeader)
+        stack.sender.sendMessage(hr)
+
+        result.punishments.forEach { punishment ->
+            val formattedDate = dateFormat.format(Date(punishment.start))
+            val punishmentMessage =
+                mh.miniMessageFormat("<blue>|   <white>#${punishment.id}</white> <blue>|</blue> <white>${punishment.type}</white> <blue>|</blue> <white>${punishment.reason}</white> <blue>|</blue> <white>$formattedDate</blue>")
+            stack.sender.sendMessage(punishmentMessage)
+        }
+        stack.sender.sendMessage(hr)
+
+        val nextPage = result.page + 1
+        val prevPage = if (result.page > 1) result.page - 1 else 1
+        val navigation =
+            mh.miniMessageFormat("<blue>| <click:run_command:'/history $player $prevPage'>[Previous]</click>   <click:run_command:'/history $player $nextPage'>[Next]</click> </blue>")
+        stack.sender.sendMessage(navigation)
+    }
+
+    private data class HistoryResult(
+        val uuid: UUID,
+        val targetPlayer: String?,
+        val punishments: List<PunishmentData>,
+        val playerIP: String?,
+        val geoLocation: String,
+        val page: Int
+    )
+
+    companion object {
+        private const val UNKNOWN_LOCATION = "Unknown location"
     }
 }

--- a/src/main/kotlin/pl/syntaxdevteam/punisher/services/PunishmentService.kt
+++ b/src/main/kotlin/pl/syntaxdevteam/punisher/services/PunishmentService.kt
@@ -1,7 +1,10 @@
 package pl.syntaxdevteam.punisher.services
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask
+import org.bukkit.scheduler.BukkitTask
 import pl.syntaxdevteam.punisher.PunisherX
 import pl.syntaxdevteam.punisher.common.TaskDispatcher
+import pl.syntaxdevteam.punisher.common.logOnError
 import pl.syntaxdevteam.punisher.databases.DatabaseHandler
 import pl.syntaxdevteam.punisher.databases.PunishmentData
 import java.util.UUID
@@ -16,10 +19,31 @@ class PunishmentService(
 
     private data class CacheEntry<T>(val value: T, val expiresAt: Long)
 
+    private enum class ListingType {
+        HISTORY,
+        BAN_ACTIVE,
+        BAN_HISTORY
+    }
+
+    private data class ListingCacheKey(
+        val type: ListingType,
+        val identifier: String?,
+        val limit: Int,
+        val offset: Int
+    )
+
     private val activePunishmentsCache = ConcurrentHashMap<UUID, CacheEntry<List<PunishmentData>>>()
+    private val listingCache = ConcurrentHashMap<ListingCacheKey, CacheEntry<List<PunishmentData>>>()
 
     @Volatile
     private var activePunishmentTtl = readCacheTtl()
+    @Volatile
+    private var listingCacheTtl = readListingCacheTtl()
+    @Volatile
+    private var cleanupIntervalTicks = readCleanupIntervalTicks()
+
+    private var cleanupTask: BukkitTask? = null
+    private var foliaCleanupTask: ScheduledTask? = null
 
     fun warmup(uuid: UUID): CompletableFuture<List<PunishmentData>> {
         return getActivePunishments(uuid, forceRefresh = true)
@@ -40,6 +64,36 @@ class PunishmentService(
         }
     }
 
+    fun getPunishmentHistory(
+        uuid: UUID,
+        limit: Int,
+        offset: Int,
+        forceRefresh: Boolean = false
+    ): CompletableFuture<List<PunishmentData>> {
+        val key = ListingCacheKey(ListingType.HISTORY, uuid.toString(), limit, offset)
+        return getListing(key, forceRefresh) {
+            databaseHandler.getPunishmentHistory(uuid.toString(), limit, offset).toList()
+        }
+    }
+
+    fun getBanList(
+        historyMode: Boolean,
+        limit: Int,
+        offset: Int,
+        forceRefresh: Boolean = false
+    ): CompletableFuture<List<PunishmentData>> {
+        val type = if (historyMode) ListingType.BAN_HISTORY else ListingType.BAN_ACTIVE
+        val key = ListingCacheKey(type, null, limit, offset)
+        return getListing(key, forceRefresh) {
+            val punishments = if (historyMode) {
+                databaseHandler.getHistoryBannedPlayers(limit, offset)
+            } else {
+                databaseHandler.getBannedPlayers(limit, offset)
+            }
+            punishments.toList()
+        }
+    }
+
     fun getCachedActivePunishments(uuid: UUID): List<PunishmentData>? {
         val now = System.currentTimeMillis()
         val cached = activePunishmentsCache[uuid] ?: return null
@@ -52,25 +106,110 @@ class PunishmentService(
 
     fun invalidateAll() {
         activePunishmentsCache.clear()
+        listingCache.clear()
     }
 
     fun removePunishment(identifier: String, type: String, removeAll: Boolean): CompletableFuture<Void> {
         return dispatcher.runAsync {
             databaseHandler.removePunishment(identifier, type, removeAll)
             runCatching { UUID.fromString(identifier) }.getOrNull()?.let { activePunishmentsCache.remove(it) }
+            listingCache.clear()
         }
     }
 
     fun refreshConfiguration() {
-        val newValue = readCacheTtl()
-        if (newValue != activePunishmentTtl) {
-            activePunishmentTtl = newValue
+        val newActiveTtl = readCacheTtl()
+        if (newActiveTtl != activePunishmentTtl) {
+            activePunishmentTtl = newActiveTtl
             activePunishmentsCache.clear()
         }
+
+        val newListingTtl = readListingCacheTtl()
+        if (newListingTtl != listingCacheTtl) {
+            listingCacheTtl = newListingTtl
+            listingCache.clear()
+        }
+
+        val newCleanupInterval = readCleanupIntervalTicks()
+        if (newCleanupInterval != cleanupIntervalTicks) {
+            cleanupIntervalTicks = newCleanupInterval
+        }
+
+        restartCleanupTask()
+    }
+
+    fun shutdown() {
+        stopCleanupTask()
     }
 
     private fun readCacheTtl(): Long {
         val configured = plugin.config.getLong("performance.cache.active-punishments-ms")
         return if (configured > 0) configured else 5000L
+    }
+
+    private fun readListingCacheTtl(): Long {
+        val configured = plugin.config.getLong("performance.cache.listings-ms")
+        return if (configured > 0) configured else 2000L
+    }
+
+    private fun readCleanupIntervalTicks(): Long {
+        val configured = plugin.config.getLong("performance.cleanup.expired-punishments-interval-ticks")
+        return if (configured > 0) configured else 20L * 60L
+    }
+
+    private fun getListing(
+        key: ListingCacheKey,
+        forceRefresh: Boolean,
+        loader: () -> List<PunishmentData>
+    ): CompletableFuture<List<PunishmentData>> {
+        val cached = listingCache[key]
+        val now = System.currentTimeMillis()
+        if (!forceRefresh && cached != null && cached.expiresAt >= now) {
+            return CompletableFuture.completedFuture(cached.value)
+        }
+
+        return dispatcher.supplyAsync {
+            val snapshot = loader().toList()
+            listingCache[key] = CacheEntry(snapshot, System.currentTimeMillis() + listingCacheTtl)
+            snapshot
+        }
+    }
+
+    private fun restartCleanupTask() {
+        stopCleanupTask()
+        if (cleanupIntervalTicks <= 0) {
+            return
+        }
+
+        if (plugin.server.name.contains("Folia", ignoreCase = true)) {
+            foliaCleanupTask = plugin.server.globalRegionScheduler.runAtFixedRate(
+                plugin,
+                { cleanupExpiredPunishments() },
+                cleanupIntervalTicks,
+                cleanupIntervalTicks
+            )
+        } else {
+            cleanupTask = plugin.server.scheduler.runTaskTimerAsynchronously(
+                plugin,
+                Runnable { cleanupExpiredPunishments() },
+                cleanupIntervalTicks,
+                cleanupIntervalTicks
+            )
+        }
+    }
+
+    private fun stopCleanupTask() {
+        cleanupTask?.cancel()
+        cleanupTask = null
+        foliaCleanupTask?.cancel()
+        foliaCleanupTask = null
+    }
+
+    private fun cleanupExpiredPunishments() {
+        dispatcher.runAsync {
+            databaseHandler.purgeExpiredPunishments(System.currentTimeMillis())
+        }.logOnError { throwable ->
+            plugin.logger.warning("Failed to purge expired punishments: ${throwable.message}")
+        }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -17,6 +17,16 @@ playerCache:
   # Choose where player IP information is stored: "file" or "database"
   storage: "file"
 
+performance:
+  cache:
+    # TTL for active punishment cache in milliseconds. Minimum 1 second.
+    active-punishments-ms: 5000
+    # TTL for command listing caches (history, banlist) in milliseconds.
+    listings-ms: 2000
+  cleanup:
+    # How often expired punishments are purged from the database (in ticks). 1200 ticks = 60 seconds.
+    expired-punishments-interval-ticks: 1200
+
 
 # /********************************************/
 #    Settings for main commands


### PR DESCRIPTION
## Summary
- add a shared `deliverToCommand` helper to deliver async results back to the main thread safely
- run Check, History and BanList queries through `TaskDispatcher` with background filtering and geo lookups
- add cached listing retrieval plus a scheduled expired-punishment purge with new performance config options
- drop synchronous expired punishment deletions from the hot-path query loop

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d4c89368a083299aa2516053526802