### PR TITLE
Replace deprecated Thread.id usage in task dispatcher

### DIFF
--- a/src/main/kotlin/pl/syntaxdevteam/punisher/common/TaskDispatcher.kt
+++ b/src/main/kotlin/pl/syntaxdevteam/punisher/common/TaskDispatcher.kt
@@ -18,7 +18,7 @@ class TaskDispatcher(private val plugin: PunisherX) : AutoCloseable {
         determinePoolSize(),
         { runnable ->
             val thread = Executors.defaultThreadFactory().newThread(runnable)
-            thread.name = "PunisherX-Async-${thread.id}"
+            thread.name = "PunisherX-Async-${thread.threadId()}"
             thread.isDaemon = true
             thread
         }


### PR DESCRIPTION
## Summary
- avoid the deprecated `Thread.id` property when naming async worker threads
- use `Thread.threadId()` to keep the generated thread names stable without relying on deprecated APIs

## Testing
- ./gradlew test --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68d558eabf0883299872a63a1d040825